### PR TITLE
I have changed the example with the Regex Type Provider in Chapter 8.

### DIFF
--- a/ExpertFSharp-master/08Text/script.fsx
+++ b/ExpertFSharp-master/08Text/script.fsx
@@ -442,7 +442,7 @@ let firstAndSecondWord (inp : string) =
 open FSharp.Text.RegexProvider
 
 type PhoneRegex = Regex< @"(?<AreaCode>^\d{3})-(?<PhoneNumber>\d{3}-\d{4}$)">
-let results = PhoneRegex().Match("425-123-2345")
+let results = PhoneRegex().TypedMatch("425-123-2345")
 let areaCode = results.AreaCode.Value
 //type PhoneRegex = Regex<...>
 //val results : Regex<...>.MatchType2 = 425-123-2345


### PR DESCRIPTION
If you ran the code as in the book then AreaCode field is not found.
But if you run TypedMatch then AreaCode is found.